### PR TITLE
Fix healthbar colors not properly updating in Monotone Attack

### DIFF
--- a/assets/legacy/data/stages/attack.hx
+++ b/assets/legacy/data/stages/attack.hx
@@ -176,7 +176,9 @@ function postModifierRegister():Void
 		iconP2.changeIcon('fabs');
 		iconP1.changeIcon('biddle');
 		
-		healthBar.setColors(gf.healthColour, biddle.healthColour);
+		FlxG.signals.postUpdate.addOnce(function() {
+			healthBar.setColors(gf.healthColour, biddle.healthColour);
+		});
 	}
 	
 	if (PlayState.attackCharacter == 1 || PlayState.attackCharacter == 2)


### PR DESCRIPTION
Something seems to have broken from 1.1.1b to 1.1.2 that causes the colors to not change when selecting Fabs or Biddle3 but this should fix it?